### PR TITLE
Improve the help command

### DIFF
--- a/help.json
+++ b/help.json
@@ -1,20 +1,22 @@
 {
-    "embeds": [{
-        "color": 6680040,
-        "author": {
-            "name": "Need help?",
-            "icon_url": "https://i.ibb.co/sHFxx0h/Emojicon.png"
+  "embeds": [
+    {
+      "description": "Give me an image to convert into emojis!\n[Invite me](https://discord.com/api/oauth2/authorize?client_id=591203757287538690&permissions=274878254080&scope=bot+applications.commands)",
+      "color": 6680040,
+      "fields": [
+        {
+          "name": "Example",
+          "value": "<@591203757287538690> 🏝️"
         },
-        "description": "Give me an image to convert into emojis!\n[Invite me](https://discordapp.com/api/oauth2/authorize?client_id=591203757287538690&permissions=0&scope=bot)",
-        "fields": [
-            {
-                "name": "Example",
-                "value": "<@591203757287538690> 🏝️"
-            },
-            {
-                "name": "Size customization",
-                "value": "<@591203757287538690> 🎉 `width`\n<@591203757287538690> 🍍 `width` `height`\n\n[Support server](https://discord.gg/xDMAxZD)\n[Vote for Emojicon](https://top.gg/bot/591203757287538690)\n[Source code on GitHub](https://github.com/charlypoirier/emojicon)"
-            }
-        ]
-    }]
+        {
+          "name": "Size Customization",
+          "value": "<@591203757287538690> 🎉 `<width>`\n<@591203757287538690> 🍍 `<width> <height>`\n\n[Support server](https://discord.gg/xDMAxZD)\n[Vote for Emojicon](https://top.gg/bot/591203757287538690)\n[Source code on GitHub](https://github.com/charlypoirier/emojicon)"
+        }
+      ],
+      "author": {
+        "name": "Need help?",
+        "icon_url": "https://i.ibb.co/sHFxx0h/Emojicon.png"
+      }
+    }
+  ]
 }

--- a/help.json
+++ b/help.json
@@ -1,7 +1,7 @@
 {
   "embeds": [
     {
-      "description": "Give me an image to convert into emojis!\n[Invite me](https://discord.com/api/oauth2/authorize?client_id=591203757287538690&permissions=274878254080&scope=bot+applications.commands)",
+      "description": "Give me an image to convert into emojis!\n[Invite me](https://discord.com/api/oauth2/authorize?client_id=591203757287538690&permissions=274878188544&scope=bot+applications.commands)",
       "color": 6680040,
       "fields": [
         {


### PR DESCRIPTION
Happy new year! This pull request adds a few small things:
- Update the invite domain from `discordapp.com` to `discord.com`
- Add a permission integer to the invite link which gives the following permissions:
  * View channels
  * Send messages
  * Send messages in threads (for future proofing)
  * Embed links
  * Read message history
  * Use external emojis (for the blank emoji)

It also includes the `applications.commands` scope, which lets you register [application commands](https://discord.com/developers/docs/interactions/application-commands). This scope is required for slash commands & context menus. Discord plans to run a second scope migration to grant the scope to all servers after the command permission system is reworked and stable, but after that developers will have to update their invite links to grant the scope (and should've already tbf).

Another small change but I added `<>` to arguments as I think it'll be more clear to users! 

### Preview
![preview](https://cdn.discordapp.com/attachments/576057292491980800/928964559983759481/unknown.png)

